### PR TITLE
Allow extra args to be passed to git

### DIFF
--- a/src/grab.rs
+++ b/src/grab.rs
@@ -8,7 +8,7 @@ use crate::Error;
 
 const HTTPS: &str = "https://";
 
-pub fn grab(home: &Path, url: OsString, dry_run: bool) -> Result<(), Error> {
+pub fn grab(home: &Path, url: OsString, dry_run: bool, git_args: &[OsString]) -> Result<(), Error> {
     let str = url.to_str().ok_or_else(|| "invalid url")?;
     let url: Url = parse_url(str)?;
 
@@ -20,7 +20,7 @@ pub fn grab(home: &Path, url: OsString, dry_run: bool) -> Result<(), Error> {
     }
 
     fs::create_dir_all(&dest_path)?;
-    let status = clone(&url, &dest_path)?;
+    let status = clone(&url, &dest_path, git_args)?;
     status
         .success()
         .then(|| ())
@@ -54,10 +54,10 @@ fn parse_url(url: &str) -> Result<Url, Error> {
     })
 }
 
-fn clone(url: &Url, dest_path: &Path) -> Result<ExitStatus, io::Error> {
-    // TODO: Support other version control systems
+fn clone(url: &Url, dest_path: &Path, extra_args: &[OsString]) -> Result<ExitStatus, io::Error> {
     Command::new("git")
         .arg("clone")
+        .args(extra_args)
         .arg(url.as_str())
         .arg(dest_path)
         .status()

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn try_main() -> Result<i32, Error> {
 
     let mut success = true;
     for url in config.grab_urls {
-        match grab(&config.home, url, config.dry_run) {
+        match grab(&config.home, url, config.dry_run, &config.git_args) {
             Ok(()) => {}
             Err(err) => {
                 eprintln!("Error: {}", err);


### PR DESCRIPTION
This allows extra arguments to be passed to git. E.g.

```
git grab https://github.com/didoesdigital/typey-type-cli -- --recurse-submodules
```

Fixes #9 

/cc @Juliaria08 