### PR TITLE
chore: Update FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,7 +34,7 @@ task:
 task:
   name: Build (FreeBSD)
   freebsd_instance:
-    image_family: freebsd-13-2
+    image_family: freebsd-13-5
     cpu: 4
   cargo_cache:
     folder: $HOME/.cargo/registry


### PR DESCRIPTION
Seems like the current one's EoL and the runner was removed.