### PR TITLE
Add --copy-path flag to copy destination path to clipboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+git-grab is a Rust CLI tool that clones Git repositories to a standardized directory structure organized by domain name and path (e.g., `~/src/github.com/user/repo`). It supports multiple URL formats and includes cross-platform clipboard integration.
+
+## Essential Commands
+
+### Build and Development
+```bash
+# Build for development
+cargo build
+
+# Build optimized release
+cargo build --release --locked
+
+# Run tests
+cargo test
+
+# Run tests without clipboard feature
+cargo test --no-default-features
+
+# Install locally
+cargo install --path .
+```
+
+### Testing
+```bash
+# Run all tests with verbose output
+cargo test --verbose
+
+# Run specific test module
+cargo test grab::tests
+cargo test clipboard::providers::tests
+```
+
+## Architecture Overview
+
+The codebase is organized into focused modules:
+
+1. **main.rs**: Entry point with simple error handling and execution flow
+2. **args.rs**: CLI argument parsing using pico-args (lightweight alternative to clap)
+3. **grab.rs**: Core logic for URL parsing, path construction, and Git operations
+4. **clipboard module**: Cross-platform clipboard abstraction with platform-specific providers
+
+### Key Design Patterns
+
+- **URL Normalization**: The `grab` module handles various URL formats (HTTPS, SSH, domain-only) and normalizes them for consistent repository paths
+- **Platform Abstraction**: Clipboard functionality uses conditional compilation and runtime detection to support macOS, Linux, Windows, and WSL
+- **Feature Flags**: Clipboard support is optional and can be disabled with `--no-default-features`
+
+### Platform-Specific Considerations
+
+- **macOS**: Uses pbcopy/pbpaste for clipboard
+- **Linux**: Auto-detects xclip, xsel, or Wayland clipboard tools
+- **Windows**: Uses native Windows clipboard API
+- **WSL**: Bridges to Windows clipboard via PowerShell
+
+## CI/CD Pipeline
+
+The project uses Cirrus CI (.cirrus.yml) for multi-platform builds:
+- Builds for Debian Linux (musl), FreeBSD, macOS (universal binary), and Windows
+- Automatically publishes release artifacts to S3
+- Runs tests on all platforms before building releases

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -8,7 +8,7 @@ use crate::Error;
 
 const HTTPS: &str = "https://";
 
-pub fn grab(home: &Path, url: OsString, dry_run: bool, git_args: &[OsString]) -> Result<(), Error> {
+pub fn grab(home: &Path, url: OsString, dry_run: bool, git_args: &[OsString]) -> Result<PathBuf, Error> {
     let str = url.to_str().ok_or("invalid url")?;
     let url: Url = parse_url(str)?;
 
@@ -16,7 +16,7 @@ pub fn grab(home: &Path, url: OsString, dry_run: bool, git_args: &[OsString]) ->
 
     if dry_run {
         println!("Grab {} to {}", url, dest_path.display());
-        return Ok(());
+        return Ok(dest_path);
     }
 
     fs::create_dir_all(&dest_path)?;
@@ -29,7 +29,10 @@ pub fn grab(home: &Path, url: OsString, dry_run: bool, git_args: &[OsString]) ->
             None => String::from("git killed by signal"),
         })
         .map_err(|err| err.into())
-        .map(|()| println!("Grabbed {} to {}", url, dest_path.display()))
+        .map(|()| {
+            println!("Grabbed {} to {}", url, dest_path.display());
+            dest_path
+        })
 }
 
 fn parse_url(url: &str) -> Result<Url, Error> {


### PR DESCRIPTION
## Summary

This PR adds a new feature to copy the local destination path to the clipboard after cloning a repository.

- Added `-p, --copy-path` CLI flag  
- Added `GRAB_COPY_PATH` environment variable support
- The feature reuses the existing clipboard infrastructure

## Implementation Details

The implementation follows the existing patterns in the codebase:
- CLI flags use both short and long forms (matching `--clipboard` pattern)
- Environment variables use the `GRAB_` prefix
- Feature is properly gated for builds without clipboard support
- Minimal changes to existing code - only modified `grab()` return type from `Result<(), Error>` to `Result<PathBuf, Error>`

## Testing

- All existing tests pass without modification
- Manually tested both the CLI flag and environment variable
- Tested with dry-run mode
- Verified clipboard functionality on macOS

## Note on Testing Philosophy

I noticed the project's testing approach focuses on unit tests for pure functions rather than integration tests. Following this pattern, I didn't add new tests since the feature leverages already-tested clipboard providers.

## Author's Note

While I've carefully reviewed all the code changes, I should mention that I'm primarily a Go and Python developer, not a Rustacean. I used Claude Code to help author this feature, and while I've read and understood all contributions, I may have missed Rust-specific idioms or best practices. I welcome any feedback or suggestions for improvement.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>