### PR TITLE
Support customizing clone path pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 
 <br>
 
-Git Grab clones a repo into `$GRAB_HOME`, organised by domain and path.
-`GRAB_HOME` defaults to `~/src` if not set or supplied via the `--home`
+Git Grab clones a repo into a local directory (based on the pattern defined by $GRAB_PATTERN).
+`GRAB_PATTERN` defaults to `~/src/{host/}{owner/}{repo}` if not set or supplied via the `--pattern`
 argument. For example:
 
     $ git grab github.com/wezm/git-grab
@@ -97,10 +97,31 @@ OPTIONS:
     -p, --copy-path
             Copy the local destination path to clipboard after cloning.
 
-        --home [default: ~/src or $GRAB_HOME]
-            The directory to use as "grab home", where the URLs will be
-            cloned into. Overrides the GRAB_HOME environment variable if
-            set.
+        --pattern <PATTERN> [default: ~/src/{host/}{owner/}{repo} or $GRAB_PATTERN]
+            Destination path pattern for grabbed repositories with optional
+            placeholders.
+
+            Placeholders are enclosed in curly braces `{}`.
+            Optionally, they may have leading and trailing `/` characters.
+            If the placeholder is present, the slashes will be added to the
+            path, otherwise they will be omitted.
+            Placeholders can be escaped by doubling the curly braces, e.g.
+            `{{owner}}` will render as `{owner}`.
+
+            The tilde `~` at the start of the pattern is expanded to the
+            home directory.
+
+            The following placeholders are supported:
+            - host  - the host part of the URL, e.g. github
+            - owner - the owner or organisation of the repo, e.g. wezm
+            - repo  - the repository name, e.g. git-grab
+            - home  - the user's home directory
+
+            Placeholders are case-sensitive, e.g. `{Repo}` or `{REPO}` is not valid.
+
+        --home (deprecated) [default: $GRAB_HOME]
+            The ~ character or {home} placeholder in the pattern expands to this
+            directory.
 
     -n, --dry-run
             Don't clone the repository but print what would be done.
@@ -110,15 +131,18 @@ OPTIONS:
 
 GIT OPTIONS:
     Arguments after `--` will be passed to the git clone invocation.
-    This can be used supply arguments like `--recurse-submodules`.
+    This can be used to supply arguments like `--recurse-submodules`.
 
 ENVIRONMENT
-    GRAB_HOME
-        See --home
+    GRAB_PATTERN
+        See --pattern
 
     GRAB_COPY_PATH
         If set, copy the local destination path to clipboard after cloning
         (equivalent to --copy-path)
+
+    GRAB_HOME (deprecated)
+        See --home
 ```
 
 A man page is also available in the source distribution.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ OPTIONS:
     -p, --copy-path
             Copy the local destination path to clipboard after cloning.
 
-        --pattern <PATTERN> [default: ~/src/{host/}{owner/}{repo} or $GRAB_PATTERN]
+        --pattern <PATTERN> [default: ~/src/{host/}{path/} or $GRAB_PATTERN]
             Destination path pattern for grabbed repositories with optional
             placeholders.
 
@@ -112,16 +112,17 @@ OPTIONS:
             home directory.
 
             The following placeholders are supported:
-            - host  - the host part of the URL, e.g. github
-            - owner - the owner or organisation of the repo, e.g. wezm
-            - repo  - the repository name, e.g. git-grab
-            - home  - the user's home directory
+            - host  - the host part of the URL, e.g. github.com
+            - path  - the path part of the URL, e.g. /wezm/git-grab
+            - owner - the owner or organisation of the repo for supported urls, e.g. wezm
+            - repo  - the repository name for supported urls, e.g. git-grab
+            - home  - the user's home directory (can be overwritten by --home or $GRAB_HOME)
 
             Placeholders are case-sensitive, e.g. `{Repo}` or `{REPO}` is not valid.
 
         --home (deprecated) [default: $GRAB_HOME]
-            The ~ character or {home} placeholder in the pattern expands to this
-            directory.
+            Overrides the value that the ~ character or {{home}} placeholder
+            will be expanded to, when evaluating the pattern.
 
     -n, --dry-run
             Don't clone the repository but print what would be done.

--- a/git-grab.1
+++ b/git-grab.1
@@ -27,7 +27,7 @@ Copy the local destination path to clipboard after cloning.
 .It Fl -pattern Ar PATTERN
 Destination path pattern for grabbed repositories with optional placeholders.
 Default is
-.Pa ~/src/{host/}{owner/}{repo}
+.Pa ~/src/{host/}{path/}
 or
 .Ev GRAB_PATTERN .
 .Pp
@@ -50,13 +50,16 @@ The following placeholders are supported:
 .Bl -dash -compact
 .It
 .Li host
-- the host part of the URL, e.g. github
+- the host part of the URL, e.g. github.com
+.It
+.Li path
+- the path part of the URL, e.g. /wezm/git-grab
 .It
 .Li owner
-- the owner or organisation of the repo, e.g. wezm
+- the owner or organisation of the repo for supported urls, e.g. wezm
 .It
 .Li repo
-- the repository name, e.g. git-grab
+- the repository name for supported urls, e.g. git-grab
 .It
 .Li home
 - the user's home directory
@@ -68,11 +71,11 @@ or
 .Li {REPO}
 is not valid.
 .It Fl -home Ar DIR No (deprecated)
-The
+Overrides the value that the
 .Li ~
 character or
 .Li {home}
-placeholder in the pattern expands to this directory.
+placeholder will be expanded to, when evaluating the pattern.
 Default is
 .Ev GRAB_HOME .
 .It Fl n, -dry-run

--- a/git-grab.1
+++ b/git-grab.1
@@ -12,7 +12,7 @@
 .Sh DESCRIPTION
 The
 .Nm
-utility clones git repositories to a standard location, organised by domain name and path.
+utility clones git repositories to a standard location based on the repository URL.
 Pass one or more
 .Ar URL
 to clone. Arguments for git may be supplied after
@@ -22,32 +22,76 @@ The following options are available:
 .Bl -tag -width indent
 .It Fl c, -clipboard
 Paste a URL to clone from the clipboard.
-.It Fl -home
-The directory to use as "grab home", where the URLs will be cloned into.
-Overrides the GRAB_HOME environment variable if set.
 .It Fl p, -copy-path
 Copy the local destination path to clipboard after cloning.
-If more than one URL is supplied the path of the last one is copied.
+.It Fl -pattern Ar PATTERN
+Destination path pattern for grabbed repositories with optional placeholders.
+Default is
+.Pa ~/src/{host/}{owner/}{repo}
+or
+.Ev GRAB_PATTERN .
+.Pp
+Placeholders are enclosed in curly braces
+.Li {}.
+Optionally, they may have leading and trailing
+.Li /
+characters.
+If the placeholder is present, the slashes will be added to the path, otherwise they will be omitted.
+Placeholders can be escaped by doubling the curly braces, e.g.
+.Li {{owner}}
+will render as
+.Li {owner} .
+.Pp
+The tilde
+.Li ~
+at the start of the pattern is expanded to the home directory.
+.Pp
+The following placeholders are supported:
+.Bl -dash -compact
+.It
+.Li host
+- the host part of the URL, e.g. github
+.It
+.Li owner
+- the owner or organisation of the repo, e.g. wezm
+.It
+.Li repo
+- the repository name, e.g. git-grab
+.It
+.Li home
+- the user's home directory
+.El
+.Pp
+Placeholders are case-sensitive, e.g.
+.Li {Repo}
+or
+.Li {REPO}
+is not valid.
+.It Fl -home Ar DIR No (deprecated)
+The
+.Li ~
+character or
+.Li {home}
+placeholder in the pattern expands to this directory.
+Default is
+.Ev GRAB_HOME .
 .It Fl n, -dry-run
 Don't clone repositories, but print what would be done.
-.It Fl h, -help
-Display a help message and exit.
 .It Fl V, -version
 Display version information and exit.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width indent
-.It Ev GRAB_HOME
-The base directory to clone into.
-If the variable
-.Ev GRAB_HOME
-is not set,
-.Pa ~/src
-is used.
+.It Ev GRAB_PATTERN
+See
+.Fl -pattern .
 .It Ev GRAB_COPY_PATH
 If set, copy the local destination path to the clipboard after cloning.
 (equivalent to
-.Op Ar --copy-path )
+.Fl -copy-path )
+.It Ev GRAB_HOME No (deprecated)
+See
+.Fl -home .
 .El
 .Sh EXIT STATUS
 .Ex -std
@@ -59,4 +103,3 @@ The
 .Nm
 utility is inspired by grab by Jeff Hodges.
 This implementation was written from scratch by Wesley Moore.
-

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,7 +15,7 @@ pub struct GrabPattern(pub String);
 
 impl Default for GrabPattern {
     fn default() -> Self {
-        Self("~/src/{host/}{owner/}{repo}".into())
+        Self("~/src/{host/}{path/}".into())
     }
 }
 
@@ -140,7 +140,7 @@ OPTIONS:
     -h, --help
             Prints help information
 {clipboard}{copy_path}
-        --pattern <PATTERN> [default: ~/src/{{host/}}{{owner/}}{{repo}} or $GRAB_PATTERN]
+        --pattern <PATTERN> [default: ~/src/{{host/}}{{path/}} or $GRAB_PATTERN]
             Destination path pattern for grabbed repositories with optional
             placeholders.
 
@@ -155,16 +155,17 @@ OPTIONS:
             home directory.
 
             The following placeholders are supported:
-            - host  - the host part of the URL, e.g. github
-            - owner - the owner or organisation of the repo, e.g. wezm
-            - repo  - the repository name, e.g. git-grab
-            - home  - the user's home directory
+            - host  - the host part of the URL, e.g. github.com
+            - path  - the path part of the URL, e.g. /wezm/git-grab
+            - owner - the owner or organisation of the repo for supported urls, e.g. wezm
+            - repo  - the repository name for supported urls, e.g. git-grab
+            - home  - the user's home directory (can be overwritten by --home or $GRAB_HOME)
 
             Placeholders are case-sensitive, e.g. `{{Repo}}` or `{{REPO}}` is not valid.
 
         --home (deprecated) [default: $GRAB_HOME]
-            The ~ character or {{home}} placeholder in the pattern expands to this
-            directory.
+            Overrides the value that the ~ character or {{home}} placeholder
+            will be expanded to, when evaluating the pattern.
 
     -n, --dry-run
             Don't clone the repository but print what would be done.

--- a/src/args.rs
+++ b/src/args.rs
@@ -11,9 +11,19 @@ const SUPPORTS_CLIPBOARD: bool = true;
 #[cfg(not(feature = "clipboard"))]
 const SUPPORTS_CLIPBOARD: bool = false;
 
+pub struct GrabPattern(pub String);
+
+impl Default for GrabPattern {
+    fn default() -> Self {
+        Self("~/src/{host/}{owner/}{repo}".into())
+    }
+}
+
 pub struct Config {
     pub dry_run: bool,
-    /// Path to source home
+    /// Pattern to use for destination paths
+    pub pattern: GrabPattern,
+    /// Home directory to use for grabs
     pub home: PathBuf,
     /// Paste the URL to clone from the clipboard
     pub clipboard: bool,
@@ -47,16 +57,26 @@ pub fn parse_args() -> Result<Option<Config>, Error> {
     let home = pargs
         .opt_value_from_os_str("--home", parse_path)?
         .or_else(|| {
-            env::var_os("GRAB_HOME").map(PathBuf::from).or_else(|| {
-                home::home_dir().map(|mut dir| {
-                    dir.push("src");
-                    dir
-                })
-            })
+            env::var_os("GRAB_HOME")
+                .map(PathBuf::from)
+                .or_else(home::home_dir)
         })
         .ok_or("unable to determine home directory")?;
+    let pattern = pargs
+        .opt_value_from_os_str("--pattern", |s| {
+            Ok::<Option<String>, &'static str>(s.to_str().map(|s| s.to_string()))
+        })?
+        .flatten()
+        .or_else(|| {
+            env::var_os("GRAB_PATTERN")
+                .and_then(|s| s.to_str().map(|s| s.to_string()))
+                .or_else(|| Some("~/src/{host/}{owner/}{repo}".into()))
+        })
+        .map(GrabPattern)
+        .ok_or("unable to determine grab pattern")?;
     let clipboard = pargs.contains(["-c", "--clipboard"]);
-    let copy_path = pargs.contains(["-p", "--copy-path"]) || env::var_os("GRAB_COPY_PATH").is_some();
+    let copy_path =
+        pargs.contains(["-p", "--copy-path"]) || env::var_os("GRAB_COPY_PATH").is_some();
 
     if (clipboard || copy_path) && !SUPPORTS_CLIPBOARD {
         return Err("this git-grab was not built with clipboard support.")?;
@@ -65,6 +85,7 @@ pub fn parse_args() -> Result<Option<Config>, Error> {
     Ok(Some(Config {
         dry_run,
         home,
+        pattern,
         clipboard,
         copy_path,
         grab_urls: pargs.finish(),
@@ -104,7 +125,7 @@ Clone a git repository into a standard location organised by domain and path.
 
 E.g. https://github.com/wezm/git-grab.git would be cloned to:
 
-    $GRAB_HOME/github.com/wezm/git-grab
+    ~/src/github.com/wezm/git-grab
 
 USAGE:
     git grab [OPTIONS] [URL]... [--] [GIT OPTIONS]
@@ -119,10 +140,31 @@ OPTIONS:
     -h, --help
             Prints help information
 {clipboard}{copy_path}
-        --home [default: ~/src or $GRAB_HOME]
-            The directory to use as \"grab home\", where the URLs will be
-            cloned into. Overrides the GRAB_HOME environment variable if
-            set.
+        --pattern <PATTERN> [default: ~/src/{{host/}}{{owner/}}{{repo}} or $GRAB_PATTERN]
+            Destination path pattern for grabbed repositories with optional
+            placeholders.
+
+            Placeholders are enclosed in curly braces `{{}}`.
+            Optionally, they may have leading and trailing `/` characters.
+            If the placeholder is present, the slashes will be added to the
+            path, otherwise they will be omitted.
+            Placeholders can be escaped by doubling the curly braces, e.g.
+            `{{{{owner}}}}` will render as `{{owner}}`.
+
+            The tilde `~` at the start of the pattern is expanded to the
+            home directory.
+
+            The following placeholders are supported:
+            - host  - the host part of the URL, e.g. github
+            - owner - the owner or organisation of the repo, e.g. wezm
+            - repo  - the repository name, e.g. git-grab
+            - home  - the user's home directory
+
+            Placeholders are case-sensitive, e.g. `{{Repo}}` or `{{REPO}}` is not valid.
+
+        --home (deprecated) [default: $GRAB_HOME]
+            The ~ character or {{home}} placeholder in the pattern expands to this
+            directory.
 
     -n, --dry-run
             Don't clone the repository but print what would be done.
@@ -132,15 +174,18 @@ OPTIONS:
 
 GIT OPTIONS:
     Arguments after `--` will be passed to the git clone invocation.
-    This can be used supply arguments like `--recurse-submodules`.
+    This can be used to supply arguments like `--recurse-submodules`.
 
 ENVIRONMENT
-    GRAB_HOME
-        See --home
-    
+    GRAB_PATTERN
+        See --pattern
+
     GRAB_COPY_PATH
         If set, copy the local destination path to clipboard after cloning
         (equivalent to --copy-path)
+
+    GRAB_HOME (deprecated)
+        See --home
 
 AUTHOR
     {}

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -1,18 +1,25 @@
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 use std::{fs, io};
 use url::{ParseError, Url};
 
+use crate::args::GrabPattern;
 use crate::Error;
 
 const HTTPS: &str = "https://";
 
-pub fn grab(home: &Path, url: OsString, dry_run: bool, git_args: &[OsString]) -> Result<PathBuf, Error> {
+pub fn grab(
+    pattern: &GrabPattern,
+    home: Option<&PathBuf>,
+    url: OsString,
+    dry_run: bool,
+    git_args: &[OsString],
+) -> Result<PathBuf, Error> {
     let str = url.to_str().ok_or("invalid url")?;
     let url: Url = parse_url(str)?;
 
-    let dest_path = clone_path(home, &url)?;
+    let dest_path = clone_path(pattern, home, &url)?;
 
     if dry_run {
         println!("Grab {} to {}", url, dest_path.display());
@@ -66,19 +73,125 @@ fn clone(url: &Url, dest_path: &Path, extra_args: &[OsString]) -> Result<ExitSta
         .status()
 }
 
-fn clone_path(home: &Path, url: &Url) -> Result<PathBuf, Error> {
-    let mut path = home.to_path_buf();
-    path.push(url.host_str().ok_or("invalid hostname")?);
-    url.path_segments()
-        .ok_or("missing path in url")?
-        .for_each(|seg| path.push(seg));
+struct UrlComponents {
+    host: Option<String>,
+    owner: Option<String>,
+    repo: Option<String>,
+}
 
-    // Strip trailing .git from clone path
-    if path.extension() == Some(OsStr::new("git")) {
-        path.set_extension("");
+fn extract_url_components(url: &Url) -> UrlComponents {
+    let host = url.host_str().map(|s| s.to_string());
+    let segments: Vec<&str> = url.path_segments().map_or(Vec::new(), |s| s.collect());
+
+    let (owner, repo) = if segments.len() >= 2
+        && (url.host_str() == Some("github.com")
+            || url.host_str() == Some("gitlab.com")
+            || url.host_str() == Some("bitbucket.org")
+            || (url.host_str() == Some("git.sr.ht")))
+    {
+        // Known hosts that follow a standard owner/repo pattern in the first two segments of the URL path
+        // E.g. https://github.com/owner/repo
+        let owner = segments.get(0).map(|s| s.to_string());
+        let repo = segments.get(1).map(|s| s.to_string());
+        (owner, repo)
+    } else if !segments.is_empty() {
+        // Other hosts - just use first segment as repo
+        let repo = segments.get(0).map(|s| s.to_string());
+        (None, repo)
+    } else {
+        (None, None)
+    };
+
+    let repo = repo.map(|r| {
+        // Remove .git extension from repo name if present
+        if r.ends_with(".git") {
+            r[..r.len() - 4].to_string()
+        } else {
+            r
+        }
+    });
+
+    UrlComponents { host, owner, repo }
+}
+
+fn clone_path(pattern: &GrabPattern, home: Option<&PathBuf>, url: &Url) -> Result<PathBuf, Error> {
+    let mut result = String::new();
+    let mut remaining = pattern.0.as_str();
+
+    if let Some(stripped) = remaining.strip_prefix('~') {
+        if let Some(home) = &home {
+            // Expand ~ to user home
+            result.push_str(&home.to_string_lossy());
+            remaining = stripped;
+        }
     }
 
-    Ok(path)
+    // Pre-compute URL components once
+    let url_components = extract_url_components(url);
+    let home_string = home.as_ref().map(|p| p.to_string_lossy().to_string());
+
+    while !remaining.is_empty() {
+        if let Some(rest) = remaining.strip_prefix('{') {
+            // Handle escaping braces
+            if rest.starts_with('{') {
+                let end = rest.find('}').ok_or("unclosed placeholder")?;
+                result.push_str(&rest[..end]);
+                remaining = &rest[end + 1..];
+                continue;
+            }
+
+            let end = rest.find('}').ok_or("unclosed placeholder")?;
+            let placeholder = &rest[..end];
+            let (leading_slash, trailing_slash) =
+                (placeholder.starts_with('/'), placeholder.ends_with('/'));
+            let placeholder = placeholder.trim_matches('/');
+
+            let value = resolve_placeholder_value(placeholder, &url_components, &home_string)?;
+
+            if let Some(val) = value {
+                if leading_slash {
+                    result.push('/');
+                }
+                result.push_str(val);
+                if trailing_slash {
+                    result.push('/');
+                }
+            }
+
+            remaining = &rest[end + 1..];
+        } else {
+            let next_brace = remaining.find('{').unwrap_or(remaining.len());
+            result.push_str(&remaining[..next_brace]);
+            remaining = &remaining[next_brace..];
+        }
+    }
+
+    Ok(PathBuf::from(result))
+}
+
+#[derive(Debug)]
+struct UnknownPlaceholderError(String);
+
+impl std::fmt::Display for UnknownPlaceholderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown placeholder: {}", self.0)
+    }
+}
+
+impl std::error::Error for UnknownPlaceholderError {}
+
+fn resolve_placeholder_value<'a>(
+    placeholder: &str,
+    components: &'a UrlComponents,
+    home_string: &'a Option<String>,
+) -> Result<Option<&'a str>, UnknownPlaceholderError> {
+    match placeholder {
+        "host" => Ok(components.host.as_deref()),
+        "home" => Ok(home_string.as_deref()),
+        "owner" => Ok(components.owner.as_deref()),
+        "repo" => Ok(components.repo.as_deref()),
+        _ => Err(UnknownPlaceholderError(placeholder.to_string())),
+    }
 }
 
 fn looks_like_ssh_url(url: &str) -> bool {
@@ -145,41 +258,179 @@ mod tests {
     }
 
     #[test]
-    fn test_clone_path() {
-        let home = Path::new("/src");
+    fn test_clone_path_valid() {
         [
             (
+                "/src/{host/}{owner/}{repo}",
                 "https://github.com/influxdata/influxdb2-sample-data.git",
                 "/src/github.com/influxdata/influxdb2-sample-data",
             ),
             (
+                "/src/{host/}{owner/}{repo}",
                 "https://github.com/influxdata/influxdb2-sample-data",
                 "/src/github.com/influxdata/influxdb2-sample-data",
             ),
-            ("github.com/zesterer/tao", "/src/github.com/zesterer/tao"),
             (
+                "/src/{host/}{owner/}{repo}",
+                "github.com/zesterer/tao",
+                "/src/github.com/zesterer/tao",
+            ),
+            (
+                "/src/{host/}{owner/}{repo}",
                 "github.com/denoland/deno/",
                 "/src/github.com/denoland/deno/",
             ),
             (
+                "/src/{host/}{owner/}{repo}",
                 "git@github.com:wezm/git-grab.git",
                 "/src/github.com/wezm/git-grab",
             ),
-            ("git.sr.ht/~wezm/lobsters", "/src/git.sr.ht/~wezm/lobsters"),
             (
+                "/src/{host/}{owner/}{repo}",
+                "git.sr.ht/~wezm/lobsters",
+                "/src/git.sr.ht/~wezm/lobsters",
+            ),
+            (
+                "/src/{host/}{owner/}{repo}",
                 "git@git.sr.ht:~wezm/lobsters",
                 "/src/git.sr.ht/~wezm/lobsters",
             ),
             (
+                "/src/{host/}{owner/}{repo}",
                 "bitbucket.org/egrange/dwscript",
                 "/src/bitbucket.org/egrange/dwscript",
             ),
-            ("git://c9x.me/qbe.git", "/src/c9x.me/qbe"),
+            (
+                "/src/{host/}{owner/}{repo}",
+                "git://c9x.me/qbe.git",
+                "/src/c9x.me/qbe",
+            ),
+            (
+                "/src/{host}/{owner}/{repo}",
+                "git://c9x.me/qbe.git",
+                "/src/c9x.me//qbe",
+            ),
+            (
+                "{host}/",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+                "github.com",
+            ),
+            (
+                "{owner}/",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+                "influxdata",
+            ),
+            (
+                "{repo}/",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+                "influxdb2-sample-data",
+            ),
+            (
+                "{home}/",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+                "/",
+            ),
+            // Leading and trailing slashes
+            (
+                "{/owner}",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+                "/influxdata",
+            ),
+            (
+                "{owner/}",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+                "influxdata/",
+            ),
+            ("{owner/}", "git://c9x.me/qbe.git", ""),
+            ("{/owner}", "git://c9x.me/qbe.git", ""),
+            (
+                "/{/owner}",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+                "//influxdata",
+            ),
+            (
+                "{owner/}/",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+                "influxdata/",
+            ),
+            // Tilde not at start
+            (
+                "/test/~/{repo}",
+                "https://example.com/example_repo.git",
+                "/test/~/example_repo",
+            ),
+            // Escaping braces
+            (
+                "/test/{{owner}}/{repo}",
+                "https://example.com/example_repo.git",
+                "/test/{owner}/example_repo",
+            ),
         ]
         .iter()
-        .for_each(|(url, expected)| {
+        .for_each(|(pattern, url, expected)| {
             assert_eq!(
-                clone_path(home, &parse_url(url).unwrap()).unwrap(),
+                clone_path(
+                    &GrabPattern((*pattern).into()),
+                    None,
+                    &parse_url(url).unwrap()
+                )
+                .unwrap(),
+                PathBuf::from(expected)
+            )
+        });
+    }
+
+    #[test]
+    fn test_clone_path_invalid() {
+        [
+            (
+                "{unknown}/",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+            ),
+            (
+                "{Host}/",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+            ),
+            (
+                "{HOST}/",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+            ),
+        ]
+        .iter()
+        .for_each(|(pattern, url)| {
+            let result = clone_path(
+                &GrabPattern((*pattern).into()),
+                None,
+                &parse_url(url).unwrap(),
+            );
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_clone_path_with_custom_home_directory() {
+        let custom_home = PathBuf::from("/custom/home");
+        [
+            (
+                "~/src/{host/}{owner/}{repo}",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+                "/custom/home/src/github.com/influxdata/influxdb2-sample-data",
+            ),
+            (
+                "{home}/src/{host/}{owner/}{repo}",
+                "https://github.com/influxdata/influxdb2-sample-data.git",
+                "/custom/home/src/github.com/influxdata/influxdb2-sample-data",
+            ),
+        ]
+        .iter()
+        .for_each(|(pattern, url, expected)| {
+            assert_eq!(
+                clone_path(
+                    &GrabPattern((*pattern).into()),
+                    Some(&custom_home),
+                    &parse_url(url).unwrap()
+                )
+                .unwrap(),
                 PathBuf::from(expected)
             )
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,13 @@ fn try_main() -> Result<i32, Error> {
         .into_iter()
         .chain(clipboard_url.into_iter())
     {
-        match grab(&config.home, url, config.dry_run, &config.git_args) {
+        match grab(
+            &config.pattern,
+            Some(&config.home),
+            url,
+            config.dry_run,
+            &config.git_args,
+        ) {
             Ok(path) => {
                 last_path = Some(path);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod args;
 #[cfg(feature = "clipboard")]
 mod clipboard;
 mod grab;
+mod pattern;
 
 use std::ffi::OsString;
 use std::{io, process};

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,0 +1,320 @@
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub enum GrabPatternPlaceholder {
+    Home,
+    Host,
+    Path,
+    Owner,
+    Repo,
+}
+
+#[derive(PartialEq, Clone, Debug)]
+pub enum GrabPatternComponent {
+    Placeholder {
+        placeholder: GrabPatternPlaceholder,
+        leading_slash: bool,
+        trailing_slash: bool,
+    },
+    Literal(String),
+}
+
+#[derive(PartialEq, Clone, Debug)]
+pub struct GrabPattern(pub Vec<GrabPatternComponent>);
+
+#[derive(PartialEq, Clone, Debug)]
+pub enum GrabPatternParseError {
+    EmptyPlaceholder,
+    UnknownPlaceholder(String),
+    UnclosedPlaceholder(String),
+    BlankPattern,
+}
+
+impl GrabPattern {
+    pub fn try_parse(input: &str) -> Result<Self, GrabPatternParseError> {
+        let mut chars: std::str::Chars<'_> = input.chars();
+
+        #[derive(PartialEq)]
+        enum ParsingMode {
+            Literal,
+            Placeholder,
+            Escape,
+        }
+
+        let mut result = Vec::new();
+
+        let mut mode = ParsingMode::Literal;
+        let mut current = String::new();
+
+        while let Some(c) = chars.next() {
+            if c == '{' && mode == ParsingMode::Literal {
+                mode = ParsingMode::Placeholder;
+                if !current.is_empty() {
+                    result.push(GrabPatternComponent::Literal(current));
+                    current = String::new();
+                }
+                continue;
+            }
+
+            if c == '{' && mode == ParsingMode::Placeholder {
+                current.push('{');
+                mode = ParsingMode::Escape;
+                continue;
+            }
+
+            if c == '{' && mode == ParsingMode::Literal {
+                mode = ParsingMode::Placeholder;
+                if !current.is_empty() {
+                    result.push(GrabPatternComponent::Literal(current));
+                    current = String::new();
+                }
+                continue;
+            }
+
+            if c == '}' && mode == ParsingMode::Escape {
+                if let Some('}') = chars.next() {
+                    current.push('}');
+                    mode = ParsingMode::Literal;
+                    continue;
+                }
+                current.push('}');
+                continue;
+            }
+
+            if c == '}' && mode == ParsingMode::Placeholder {
+                mode = ParsingMode::Literal;
+
+                if current.is_empty() {
+                    return Err(GrabPatternParseError::EmptyPlaceholder);
+                }
+
+                let placeholder_str = current.as_str();
+                let mut start = 0;
+                let mut end = placeholder_str.len();
+                let mut leading_slash = false;
+                let mut trailing_slash = false;
+
+                if placeholder_str.starts_with('/') {
+                    leading_slash = true;
+                    start += 1;
+                }
+
+                if placeholder_str.ends_with('/') {
+                    trailing_slash = true;
+                    end -= 1;
+                }
+
+                let placeholder = match &placeholder_str[start..end] {
+                    "home" => GrabPatternPlaceholder::Home,
+                    "host" => GrabPatternPlaceholder::Host,
+                    "path" => GrabPatternPlaceholder::Path,
+                    "owner" => GrabPatternPlaceholder::Owner,
+                    "repo" => GrabPatternPlaceholder::Repo,
+                    "" => return Err(GrabPatternParseError::EmptyPlaceholder),
+                    _ => return Err(GrabPatternParseError::UnknownPlaceholder(current)),
+                };
+
+                result.push(GrabPatternComponent::Placeholder {
+                    placeholder,
+                    leading_slash,
+                    trailing_slash,
+                });
+
+                current = String::new();
+                continue;
+            }
+
+            current.push(c);
+        }
+
+        if mode == ParsingMode::Placeholder {
+            return Err(GrabPatternParseError::UnclosedPlaceholder(current));
+        }
+
+        if !current.is_empty() {
+            result.push(GrabPatternComponent::Literal(current));
+        }
+
+        if result.is_empty()
+            || result.iter().all(|comp| {
+                matches!(comp,
+                    GrabPatternComponent::Literal(s) if s.trim().is_empty()
+                )
+            })
+        {
+            return Err(GrabPatternParseError::BlankPattern);
+        }
+
+        Ok(Self(result))
+    }
+}
+
+impl Default for GrabPattern {
+    fn default() -> Self {
+        // Default pattern: ~/src/{host/}{path/}
+        GrabPattern(vec![
+            GrabPatternComponent::Literal("~/src/".into()),
+            GrabPatternComponent::Placeholder {
+                placeholder: GrabPatternPlaceholder::Host,
+                leading_slash: false,
+                trailing_slash: true,
+            },
+            GrabPatternComponent::Placeholder {
+                placeholder: GrabPatternPlaceholder::Path,
+                leading_slash: false,
+                trailing_slash: true,
+            },
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_default_pattern() {
+        let parsed = GrabPattern::try_parse("~/src/{host/}{path/}").unwrap();
+        assert_eq!(parsed, GrabPattern::default());
+    }
+
+    #[test]
+    fn test_parse_valid_placeholders() {
+        assert_eq!(
+            GrabPattern::try_parse("{home}"),
+            Ok(GrabPattern(vec![GrabPatternComponent::Placeholder {
+                placeholder: GrabPatternPlaceholder::Home,
+                leading_slash: false,
+                trailing_slash: false,
+            }]))
+        );
+
+        assert_eq!(
+            GrabPattern::try_parse("{host}"),
+            Ok(GrabPattern(vec![GrabPatternComponent::Placeholder {
+                placeholder: GrabPatternPlaceholder::Host,
+                leading_slash: false,
+                trailing_slash: false,
+            }]))
+        );
+
+        assert_eq!(
+            GrabPattern::try_parse("{path}"),
+            Ok(GrabPattern(vec![GrabPatternComponent::Placeholder {
+                placeholder: GrabPatternPlaceholder::Path,
+                leading_slash: false,
+                trailing_slash: false,
+            }]))
+        );
+
+        assert_eq!(
+            GrabPattern::try_parse("{owner}"),
+            Ok(GrabPattern(vec![GrabPatternComponent::Placeholder {
+                placeholder: GrabPatternPlaceholder::Owner,
+                leading_slash: false,
+                trailing_slash: false,
+            }]))
+        );
+
+        assert_eq!(
+            GrabPattern::try_parse("{repo}"),
+            Ok(GrabPattern(vec![GrabPatternComponent::Placeholder {
+                placeholder: GrabPatternPlaceholder::Repo,
+                leading_slash: false,
+                trailing_slash: false,
+            }]))
+        );
+    }
+
+    #[test]
+    fn test_parse_leading_slash() {
+        assert_eq!(
+            GrabPattern::try_parse("{/home}"),
+            Ok(GrabPattern(vec![GrabPatternComponent::Placeholder {
+                placeholder: GrabPatternPlaceholder::Home,
+                leading_slash: true,
+                trailing_slash: false,
+            }]))
+        );
+    }
+
+    #[test]
+    fn test_parse_trailing_slash() {
+        assert_eq!(
+            GrabPattern::try_parse("{home/}"),
+            Ok(GrabPattern(vec![GrabPatternComponent::Placeholder {
+                placeholder: GrabPatternPlaceholder::Home,
+                leading_slash: false,
+                trailing_slash: true,
+            }]))
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_casing() {
+        assert_eq!(
+            GrabPattern::try_parse("{Home}"),
+            Err(GrabPatternParseError::UnknownPlaceholder("Home".into()))
+        );
+        assert_eq!(
+            GrabPattern::try_parse("{HOME}"),
+            Err(GrabPatternParseError::UnknownPlaceholder("HOME".into()))
+        );
+    }
+
+    #[test]
+    fn test_parse_escaping() {
+        assert_eq!(
+            GrabPattern::try_parse("{{home}}"),
+            Ok(GrabPattern(vec![GrabPatternComponent::Literal(
+                "{home}".into()
+            )]))
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_closing_brace() {
+        assert_eq!(
+            GrabPattern::try_parse("{home"),
+            Err(GrabPatternParseError::UnclosedPlaceholder("home".into()))
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_placeholder() {
+        assert_eq!(
+            GrabPattern::try_parse("{}"),
+            Err(GrabPatternParseError::EmptyPlaceholder)
+        );
+    }
+
+    #[test]
+    fn test_parse_unknown_placeholder() {
+        assert_eq!(
+            GrabPattern::try_parse("{unknown}"),
+            Err(GrabPatternParseError::UnknownPlaceholder("unknown".into()))
+        );
+        assert_eq!(
+            GrabPattern::try_parse("{abc}"),
+            Err(GrabPatternParseError::UnknownPlaceholder("abc".into()))
+        );
+        assert_eq!(
+            GrabPattern::try_parse("{🐈}"),
+            Err(GrabPatternParseError::UnknownPlaceholder("🐈".into()))
+        );
+    }
+
+    #[test]
+    fn test_parse_blank() {
+        assert_eq!(
+            GrabPattern::try_parse(""),
+            Err(GrabPatternParseError::BlankPattern)
+        );
+        assert_eq!(
+            GrabPattern::try_parse(" "),
+            Err(GrabPatternParseError::BlankPattern)
+        );
+        assert_eq!(
+            GrabPattern::try_parse("\t"),
+            Err(GrabPatternParseError::BlankPattern)
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a `--pattern` argument (and `GRAB_PATTERN` env var) as an alternative to the `--home` argument and `GRAB_HOME` env variable, allowing users to customize destination paths move heavily using variables extracted from the git url.

I did my best to match the style of the existing code and ensure there are no clippy issues. Please let me know if there's anything I should change :)